### PR TITLE
reset-all playbook, metrics_credentials bug, httpd failure to restart bug, updated ansible/cleanup/README

### DIFF
--- a/ansible/cleanup/README.md
+++ b/ansible/cleanup/README.md
@@ -27,4 +27,10 @@ Stops all CFME/Miq Services, then deletes all log files in /var/www/miq/vmdb/log
 ```
 [root@perf ansible]# ansible-playbook -i hosts.local cleanup/reset-database.yml
 ```
-Stops evmserverd, drops file system cache, restarts Postgres, removes replication, resets database, seeds database, and starts services.  Briefly stops collectd in addition to evmserverd due to the Postgres connection from the collectd configuration.
+Stops evmserverd, drops file system cache, restarts Postgres, removes replication, resets database, seeds database, deletes all files in /run/httpd/, and starts services.  Briefly stops collectd in addition to evmserverd due to the Postgres connection from the collectd configuration.
+
+## reset-all.yml
+```
+[root@perf ansible]# ansible-playbook -i hosts.local cleanup/reset-all.yml
+```
+Stops evmserverd and all CFME/Miq Services, drops file system cache, restarts Postgres, removes replication, resets database, seeds database, deletes all log files in /var/www/miq/vmdb/log/ and /var/www/miq/vmdb/log/apache/ and deletes all files in /run/httpd/, and then starts services.  Briefly stops collectd in addition to evmserverd due to the Postgres connection from the collectd configuration.

--- a/ansible/cleanup/reset-all.yml
+++ b/ansible/cleanup/reset-all.yml
@@ -1,0 +1,13 @@
+---
+#
+# Playbook to reset cfme appliance database, Clean logs, and restart CFME/Miq Services
+#
+
+- hosts: cfme-vmdb,cfme-all-in-one
+  gather_facts: false
+  remote_user: root
+  vars_files:
+    - ../group_vars/all.yml
+    - ../group_vars/all.local.yml
+  roles:
+    - reset-all

--- a/ansible/cleanup/roles/reset-all/tasks/main.yml
+++ b/ansible/cleanup/roles/reset-all/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 #
-# Tasks to Reset Cloud Forms VMDB
+# Tasks to Reset Cloud Forms VMDB and to delete all log files
+#
+# Note: deleting all log files involves restarting CFME services
 #
 
 - name: Stop services
@@ -8,6 +10,9 @@
   with_items:
     - evmserverd
     - collectd
+    - miqtop
+    - miqvmstat
+    - httpd
 
 - name: Drop FS caches
   shell: sync; sync; echo 3 > /proc/sys/vm/drop_caches
@@ -27,8 +32,17 @@
 - name: Work around for https://bugzilla.redhat.com/show_bug.cgi?id=1337525
   shell: "rm -rf /run/httpd/*"
 
+- name: Delete log files
+  shell: rm -f {{item}}
+  with_items:
+    - /var/www/miq/vmdb/log/*.log*
+    - /var/www/miq/vmdb/log/apache/*.log*
+
 - name: Start services
   service: name={{item}} state=started
   with_items:
+    - miqtop
+    - miqvmstat
     - evmserverd
     - collectd
+    - httpd

--- a/cfme-performance/utils/providers.py
+++ b/cfme-performance/utils/providers.py
@@ -4,6 +4,88 @@ import json
 import requests
 
 
+def get_all_provider_ids():
+    """Returns an integer list of provider ID's via the Rest API"""
+    logger.debug('Retrieving the list of provider ids')
+
+    provider_ids = []
+    provider_response = requests.get(
+        url="https://" + cfme_performance['appliance']['ip_address'] + "/api/providers",
+        auth=(cfme_performance['appliance']['rest_api']['username'],
+              cfme_performance['appliance']['rest_api']['password']),
+        verify=False
+    )
+
+    provider_json = provider_response.json()
+    provider_urls = provider_json['resources']
+    for url in provider_urls:
+        last_slash = url['href'].rfind('/')
+        provider_ids.append(int(url['href'][last_slash + 1:]))
+
+    return provider_ids
+
+
+def get_all_vm_ids():
+    """Returns an integer list of vm ID's via the Rest API"""
+    logger.debug('Retrieving the list of vm ids')
+
+    vm_ids = []
+    vm_response = requests.get(
+        url="https://" + cfme_performance['appliance']['ip_address'] + "/api/vms",
+        auth=(cfme_performance['appliance']['rest_api']['username'],
+              cfme_performance['appliance']['rest_api']['password']),
+        verify=False
+    )
+
+    vm_json = vm_response.json()
+    vm_urls = vm_json['resources']
+    for url in vm_urls:
+        last_slash = url['href'].rfind('/')
+        vm_ids.append(int(url['href'][last_slash + 1:]))
+
+    return vm_ids
+
+
+def get_provider_details(provider_id):
+    """Returns the id, name, and type associated with the provider_id"""
+    logger.debug('Retrieving the provider details for ID: {}'.format(provider_id))
+
+    id_details = {}
+    id_response = requests.get(
+        url="https://" + cfme_performance['appliance']['ip_address'] +
+            "/api/providers/" + str(provider_id),
+        auth=(cfme_performance['appliance']['rest_api']['username'],
+              cfme_performance['appliance']['rest_api']['password']),
+        verify=False
+    )
+    id_json = id_response.json()
+
+    id_details['name'] = str(id_json['name'])
+    id_details['type'] = str(id_json['type'])
+
+    return id_details
+
+
+def get_vm_details(vm_id):
+    """Returns the id, name, and type associated with the vm_id"""
+    logger.debug('Retrieving the vm details for ID: {}'.format(vm_id))
+
+    vmid_details = {}
+    vmid_response = requests.get(
+        url="https://" + cfme_performance['appliance']['ip_address'] +
+            "/api/vms/" + str(vm_id),
+        auth=(cfme_performance['appliance']['rest_api']['username'],
+              cfme_performance['appliance']['rest_api']['password']),
+        verify=False
+    )
+    vmid_json = vmid_response.json()
+
+    vmid_details['name'] = str(vmid_json['name'])
+    vmid_details['type'] = str(vmid_json['type'])
+
+    return vmid_details
+
+
 def add_provider(provider):
     """Adds Provider via the Rest API."""
     logger.debug('Adding Provider: {}, Type: {}'.format(provider['name'], provider['type']))
@@ -21,7 +103,7 @@ def add_provider(provider):
         }]
     }
 
-    if 'metrics credentials' in provider:
+    if 'metrics_credentials' in provider:
         data_dict['resources'][0]['credentials'].append({
             "userid": provider['metrics_credentials']['username'],
             "password": provider['metrics_credentials']['password'],
@@ -49,11 +131,11 @@ def add_providers(providers):
         add_provider(cfme_performance['providers'][provider])
 
 
-def refresh_provider(provider):
-    logger.debug('TODO: Initiate Provider Refresh')
+def refresh_provider(provider_id):
+    logger.debug('Refreshing Provider with id: {}'.format(provider_id))
 
     appliance = cfme_performance['appliance']['ip_address']
-    response = requests.post("https://" + appliance + "/api/providers/" + ID,  # TODO find out ID
+    response = requests.post("https://" + appliance + "/api/providers/" + str(provider_id),
                              data=json.dumps({"action": "refresh"}),
                              auth=(cfme_performance['appliance']['rest_api']['username'],
                                    cfme_performance['appliance']['rest_api']['password']),
@@ -61,18 +143,18 @@ def refresh_provider(provider):
                              headers={"content-type": "application/json"},
                              allow_redirects=False)
 
-    logger.debug('Refreshed Provider: {}, Response: {}'.format(provider['name'], response))
+    logger.debug('Refreshed Provider: {}, Response: {}'.format(provider_id, response))
 
 
 def refresh_provider_host(provider):
     logger.debug('TODO: Initiate Provider Host Refresh')
 
 
-def refresh_provider_vm(provider):
-    logger.debug('TODO: Initiate Provider VM Refresh')
+def refresh_provider_vm(vm_id):
+    logger.debug('Refreshing VM with ID: {}'.format(vm_id))
 
     appliance = cfme_performance['appliance']['ip_address']
-    response = requests.post("https://" + appliance + "/api/vms/",
+    response = requests.post("https://" + appliance + "/api/vms/" + str(vm_id),
                              data=json.dumps({"action": "refresh"}),
                              auth=(cfme_performance['appliance']['rest_api']['username'],
                                    cfme_performance['appliance']['rest_api']['password']),
@@ -80,5 +162,4 @@ def refresh_provider_vm(provider):
                              headers={"content-type": "application/json"},
                              allow_redirects=False)
 
-    logger.debug('The response for refreshing Provider VM: {} is: {}'
-    .format(provider['name'], response.json()))
+    logger.debug('Refreshed VM: {}, Response: {}'.format(vm_id, response))


### PR DESCRIPTION
Added a reset-all playbook to ansible/cleanup
Fixed the providers.py bug where 'metrics credentials' should have been 'metrics_credentials', and the if statement would never execute
Added work around for https://bugzilla.redhat.com/show_bug.cgi?id=1337525 to the ansible/cleanup/reset-database playbook
Updated ansible/cleanup/README.md to accommodate the reset-all playbook, and the workaround for httpd reset-database
