### PR TITLE
Add refresh workloads to python testing framework

### DIFF
--- a/cfme-performance/conf/cfme_performance.yml
+++ b/cfme-performance/conf/cfme_performance.yml
@@ -85,3 +85,41 @@ workloads:
           - rhevm-small
         refresh_sleep_time: 600
         total_time: 14400
+  test_refresh_providers:
+    scenarios:
+      - name: 30m-refresh-providers-vmware-small
+        providers:
+          - vmware-small
+        refresh_sleep_time: 600
+        refresh_size: 5
+        wait_time: 10
+        total_time: 1800
+        grafana_dashboard: cfme-vmware-system-performance
+      - name: 4hr-refresh-providers-rhevm-small
+        providers:
+          - rhevm-small
+        refresh_sleep_time: 600
+        refresh_size: 5
+        wait_time: 10
+        total_time: 14400
+        grafana_dashboard: cfme-redhat-system-performance
+  test_refresh_vms:
+    scenarios:
+      - name: 30m-vm-refresh-vms-vmware-small
+        providers:
+          - vmware-small
+        refresh_sleep_time: 600
+        refresh_size: 5
+        refresh_threshold: 100
+        wait_time: 10
+        total_time: 1800
+        grafana_dashboard: cfme-vmware-system-performance
+      - name: 4hr-vm-refresh-vms-rhevm-small
+        providers:
+          - rhevm-small
+        refresh_sleep_time: 600
+        refresh_size: 5
+        refresh_threshold: 100
+        wait_time: 10
+        total_time: 14400
+        grafana_dashboard: cfme-redhat-system-performance

--- a/cfme-performance/tests/workloads/test_refresh_providers.py
+++ b/cfme-performance/tests/workloads/test_refresh_providers.py
@@ -1,0 +1,94 @@
+"""Runs Refresh Workload by adding specified providers, and refreshing a specified number, waiting,
+then repeating for specified length of time."""
+from utils.appliance import clean_appliance
+from utils.appliance import get_server_roles_workload_refresh_providers
+from utils.appliance import set_server_roles_workload_refresh_providers
+from utils.appliance import wait_for_miq_server_ready
+from utils.grafana import get_scenario_dashboard_url
+from utils.log import logger
+from utils.providers import add_providers
+from utils.providers import get_all_provider_ids
+from utils.providers import refresh_providers
+from utils.smem_memory_monitor import SmemMemoryMonitor
+from utils.ssh import SSHClient
+from utils.workloads import get_refresh_providers_scenarios
+import time
+import pytest
+
+
+@pytest.mark.parametrize('scenario', get_refresh_providers_scenarios())
+def test_refresh_rapid(request, scenario):
+    """Refreshes a specified number of providers then waits for a specific amount of time.
+    Memory Monitor creates graphs and summary at the end of the scenario."""
+    from_ts = int(time.time() * 1000)
+    ssh_client = SSHClient()
+    logger.debug('Scenario: {}'.format(scenario['name']))
+
+    clean_appliance(ssh_client)
+
+    monitor_thread = SmemMemoryMonitor(SSHClient(), 'workload-refresh-providers', scenario['name'],
+    'refresh-providers', get_server_roles_workload_refresh_providers(separator=','),
+    ', '.join(scenario['providers']))
+
+    def cleanup_workload(scenario, from_ts):
+        start_time = time.time()
+        to_ts = int(start_time * 1000)
+        g_url = get_scenario_dashboard_url(scenario, from_ts, to_ts)
+        logger.debug('Started cleaning up monitoring thread.')
+        monitor_thread.grafana_url = g_url
+        monitor_thread.signal = False
+        monitor_thread.join()
+        timediff = time.time() - start_time
+        logger.info('Finished cleaning up monitoring thread in {}'.format(timediff))
+    request.addfinalizer(lambda: cleanup_workload(scenario, from_ts))
+
+    monitor_thread.start()
+
+    wait_for_miq_server_ready(poll_interval=2)
+    set_server_roles_workload_refresh_providers(ssh_client)
+    add_providers(scenario['providers'])
+    logger.info('Sleeping for refresh: {}s'.format(scenario['refresh_sleep_time']))
+    time.sleep(scenario['refresh_sleep_time'])
+
+    def get_refresh_ids(start_id, size, list):
+        """"""
+        refresh_list = []
+        if start_id != 0:
+            list = list[start_id:] + list[0:start_id]
+        if size > len(list):
+                fullTimes = size / len(list)
+                leftOver = size % len(list)
+        else:
+                fullTimes = 0
+                leftOver = size
+        i = 0
+        while i < fullTimes:
+                refresh_list = refresh_list + list
+                i += 1
+        refresh_list = refresh_list + list[0:leftOver]
+        return {'new_start_id': (start_id + size) % len(list), 'ids_to_refresh': refresh_list}
+
+    start_id = 0
+    refresh_size = scenario['refresh_size']
+    id_list = get_all_provider_ids()
+
+    # Variable amount of time for refresh workload
+    total_time = scenario['total_time']
+    start_time = time.time()
+    wait_time = scenario['wait_time']
+    elapsed_time = 0
+
+    while (elapsed_time < total_time):
+        elapsed_time = time.time() - start_time
+        time_left = abs(total_time - elapsed_time)
+        logger.info('Time elapsed: {}/{}'.format(round(elapsed_time, 2), total_time))
+        refresh_dict = get_refresh_ids(start_id, refresh_size, id_list)
+        start_id = refresh_dict['new_start_id']
+        refresh_providers(refresh_dict['ids_to_refresh'])
+
+        if time_left < wait_time:
+            time.sleep(time_left)
+        else:
+            time.sleep(wait_time)
+
+    logger.info('Test Ending...')

--- a/cfme-performance/tests/workloads/test_refresh_vms.py
+++ b/cfme-performance/tests/workloads/test_refresh_vms.py
@@ -1,0 +1,96 @@
+"""Runs Refresh Workload by adding specified providers, and refreshing a specified number of vms,
+waiting, then repeating for specified length of time."""
+from utils.appliance import clean_appliance
+from utils.appliance import get_server_roles_workload_refresh_vms
+from utils.appliance import set_server_roles_workload_refresh_vms
+from utils.appliance import wait_for_miq_server_ready
+from utils.appliance import set_full_refresh_threshold
+from utils.grafana import get_scenario_dashboard_url
+from utils.log import logger
+from utils.providers import add_providers
+from utils.providers import get_all_vm_ids
+from utils.providers import refresh_provider_vms
+from utils.smem_memory_monitor import SmemMemoryMonitor
+from utils.ssh import SSHClient
+from utils.workloads import get_refresh_vms_scenarios
+import time
+import pytest
+
+
+@pytest.mark.parametrize('scenario', get_refresh_vms_scenarios())
+def test_refresh_vms(request, scenario):
+    """Refreshes all vm's then waits for a specific amount of time. Memory Monitor creates
+    graphs and summary at the end of the scenario."""
+    from_ts = int(time.time() * 1000)
+    ssh_client = SSHClient()
+    logger.debug('Scenario: {}'.format(scenario['name']))
+
+    clean_appliance(ssh_client)
+
+    monitor_thread = SmemMemoryMonitor(SSHClient(), 'workload-refresh-vm', scenario['name'],
+    'refresh-vm', get_server_roles_workload_refresh_vms(separator=','),
+    ', '.join(scenario['providers']))
+
+    def cleanup_workload(scenario, from_ts):
+        start_time = time.time()
+        to_ts = int(start_time * 1000)
+        g_url = get_scenario_dashboard_url(scenario, from_ts, to_ts)
+        logger.debug('Started cleaning up monitoring thread.')
+        monitor_thread.grafana_url = g_url
+        monitor_thread.signal = False
+        monitor_thread.join()
+        timediff = time.time() - start_time
+        logger.info('Finished cleaning up monitoring thread in {}'.format(timediff))
+    request.addfinalizer(lambda: cleanup_workload(scenario, from_ts))
+
+    monitor_thread.start()
+
+    wait_for_miq_server_ready(poll_interval=2)
+    set_server_roles_workload_refresh_vms(ssh_client)
+    add_providers(scenario['providers'])
+    logger.info('Sleeping for refresh: {}s'.format(scenario['refresh_sleep_time']))
+    time.sleep(scenario['refresh_sleep_time'])
+    set_full_refresh_threshold(ssh_client, scenario['refresh_threshold'])
+
+    def get_refresh_ids(start_id, size, list):
+        """"""
+        refresh_list = []
+        if start_id != 0:
+            list = list[start_id:] + list[0:start_id]
+        if size > len(list):
+                fullTimes = size / len(list)
+                leftOver = size % len(list)
+        else:
+                fullTimes = 0
+                leftOver = size
+        i = 0
+        while i < fullTimes:
+                refresh_list = refresh_list + list
+                i += 1
+        refresh_list = refresh_list + list[0:leftOver]
+        return {'new_start_id': (start_id + size) % len(list), 'ids_to_refresh': refresh_list}
+
+    start_id = 0
+    refresh_size = scenario['refresh_size']
+    id_list = get_all_vm_ids()
+
+    # Variable amount of time for refresh workload
+    total_time = scenario['total_time']
+    start_time = time.time()
+    wait_time = scenario['wait_time']
+    elapsed_time = 0
+
+    while (elapsed_time < total_time):
+        elapsed_time = time.time() - start_time
+        time_left = abs(total_time - elapsed_time)
+        logger.info('Time elapsed: {}/{}'.format(round(elapsed_time, 2), total_time))
+        refresh_dict = get_refresh_ids(start_id, refresh_size, id_list)
+        start_id = refresh_dict['new_start_id']
+        refresh_provider_vms(refresh_dict['ids_to_refresh'])
+
+        if time_left < wait_time:
+            time.sleep(time_left)
+        else:
+            time.sleep(wait_time)
+        logger.info('sleeping for {}s between refresh cycles'.format(wait_time))
+    logger.info('Test Ending...')

--- a/cfme-performance/utils/appliance.py
+++ b/cfme-performance/utils/appliance.py
@@ -30,6 +30,14 @@ roles56_cap_and_util = ['automate', 'database_operations', 'ems_inventory', 'ems
     'ems_metrics_coordinator', 'ems_metrics_processor', 'ems_operations', 'event', 'notifier',
     'reporting', 'scheduler', 'user_interface', 'web_services']
 
+# TODO: set the roles
+roles56_refresh_providers = ['automate', 'database_operations', 'ems_inventory', 'ems_operations',
+    'event', 'reporting', 'scheduler', 'smartstate', 'user_interface', 'web_services', 'websocket']
+
+# TODO: set the roles
+roles56_refresh_vms = ['automate', 'database_operations', 'ems_inventory', 'ems_operations',
+    'event', 'reporting', 'scheduler', 'smartstate', 'user_interface', 'web_services', 'websocket']
+
 roles56_smartstate = ['automate', 'database_operations', 'ems_inventory', 'ems_operations', 'event',
     'notifier', 'reporting', 'scheduler', 'smartproxy', 'smartstate', 'user_interface',
     'web_services']
@@ -85,6 +93,12 @@ def set_vmdb_yaml_config(ssh_client, yaml_data):
         logger.info('Set VMDB Config')
 
 
+def set_full_refresh_threshold(ssh_client, threshold=100):
+    yaml = get_vmdb_yaml_config(ssh_client)
+    yaml['ems_refresh']['full_refresh_threshold'] = threshold
+    set_vmdb_yaml_config(ssh_client, yaml)
+
+
 def get_server_roles_workload_idle_default(separator=','):
     return separator.join(roles56_default)
 
@@ -99,6 +113,14 @@ def get_server_roles_workload_idle_all(separator=','):
 
 def get_server_roles_workload_cap_and_util(separator=','):
     return separator.join(roles56_cap_and_util)
+
+
+def get_server_roles_workload_refresh_providers(separator=','):
+    return separator.join(roles56_refresh_providers)
+
+
+def get_server_roles_workload_refresh_vms(separator=','):
+    return separator.join(roles56_refresh_vms)
 
 
 def get_server_roles_workload_smartstate(separator=','):
@@ -131,6 +153,20 @@ def set_server_roles_workload_cap_and_util(ssh_client):
     """Sets server roles used for all C&U workloads."""
     yaml = get_vmdb_yaml_config(ssh_client)
     yaml['server']['role'] = get_server_roles_workload_cap_and_util()
+    set_vmdb_yaml_config(ssh_client, yaml)
+
+
+def set_server_roles_workload_refresh_providers(ssh_client):
+    """Sets server roles used for all refresh_providers workloads."""
+    yaml = get_vmdb_yaml_config(ssh_client)
+    yaml['server']['role'] = get_server_roles_workload_refresh_providers()
+    set_vmdb_yaml_config(ssh_client, yaml)
+
+
+def set_server_roles_workload_refresh_vms(ssh_client):
+    """Sets server roles used for all refresh_vms workloads"""
+    yaml = get_vmdb_yaml_config(ssh_client)
+    yaml['server']['role'] = get_server_roles_workload_refresh_vms()
     set_vmdb_yaml_config(ssh_client, yaml)
 
 

--- a/cfme-performance/utils/workloads.py
+++ b/cfme-performance/utils/workloads.py
@@ -7,3 +7,24 @@ def get_capacity_and_utilization_scenarios():
             len(cfme_performance['workloads']['test_cap_and_util']['scenarios']) > 0):
         return cfme_performance['workloads']['test_cap_and_util']['scenarios']
     return []
+
+
+def get_refresh_providers_scenarios():
+    if (cfme_performance['workloads']['test_refresh_providers']['scenarios'] and
+            len(cfme_performance['workloads']['test_refresh_providers']['scenarios']) > 0):
+        return cfme_performance['workloads']['test_refresh_providers']['scenarios']
+    return []
+
+
+def get_refresh_vms_scenarios():
+    if (cfme_performance['workloads']['test_refresh_vms']['scenarios'] and
+            len(cfme_performance['workloads']['test_refresh_vms']['scenarios']) > 0):
+        return cfme_performance['workloads']['test_refresh_vms']['scenarios']
+    return []
+
+
+def get_smartstate_scenarios():
+    if(cfme_performance['workloads']['test_smartstate']['scenarios'] and
+            len(cfme_performance['workloads']['test_smartstate']['scenarios']) > 0):
+        return cfme_performance['workloads']['test_smartstate']['scenarios']
+    return []


### PR DESCRIPTION
Create refresh workloads to test the refresh of:

```
    - Refreshing all providers in order, then wait and repeat

    - Refreshing one provider, waiting, and then refreshing the next, etc.

    - Refreshing all VM's in order, then wait and repeat

    - Refreshing one VM, waiting, and then refreshing the next, etc.
```

Add more details to get_vm_details() method in providers.py

Add methods to providers.py:

```
    - shutdown_vm()

    - reboot_vm()

    - start_vm()

    - stop_vm()

    - suspend_vm()

    - reset_vm()
```
