### PR TITLE
Add changes to refresh workloads to increase clarity

### DIFF
--- a/cfme-performance/conf/cfme_performance.yml
+++ b/cfme-performance/conf/cfme_performance.yml
@@ -34,6 +34,9 @@ providers:
     credentials:
       username: administrator@vsphere.local
       password: password
+    host_credentials:
+      username: administrator@vsphere.local
+      password: password
   rhevm-small:
     name: rhevm-small
     type: ManageIQ::Providers::Redhat::InfraManager
@@ -95,14 +98,14 @@ workloads:
       - name: 30m-vmware-small
         providers:
           - vmware-small
-        wait_time: 60
+        time_between_refresh: 60
         total_time: 1800
         grafana_dashboard: cfme-vmware-system-performance
       - name: 30m-2xsmall-vmware-rhevm
         providers:
           - vmware-small
           - rhevm-small
-        wait_time: 60
+        time_between_refresh: 60
         total_time: 1800
         grafana_dashboard: cfme-general-system-performance
   test_refresh_vms:
@@ -110,18 +113,20 @@ workloads:
       - name: 30m-vmware-small
         providers:
           - vmware-small
+        refresh_sleep_time: 60
         refresh_size: 5
-        refresh_threshold: 100
-        wait_time: 10
+        full_refresh_threshold: 100
+        time_between_refresh: 10
         total_time: 1800
         grafana_dashboard: cfme-vmware-system-performance
       - name: 30m-2xsmall-vmware-rhevm
         providers:
           - vmware-small
           - rhevm-small
+        refresh_sleep_time: 60
         refresh_size: 5
-        refresh_threshold: 100
-        wait_time: 10
+        full_refresh_threshold: 100
+        time_between_refresh: 10
         total_time: 1800
         grafana_dashboard: cfme-general-system-performance
   test_smartstate:

--- a/cfme-performance/tests/workloads/test_refresh_providers.py
+++ b/cfme-performance/tests/workloads/test_refresh_providers.py
@@ -52,18 +52,23 @@ def test_refresh_providers(request, scenario):
     # Variable amount of time for refresh workload
     total_time = scenario['total_time']
     start_time = time.time()
-    wait_time = scenario['wait_time']
+    time_between_refresh = scenario['time_between_refresh']
     elapsed_time = 0
 
     while (elapsed_time < total_time):
         elapsed_time = time.time() - start_time
         time_left = abs(total_time - elapsed_time)
         logger.info('Time elapsed: {}/{}'.format(round(elapsed_time, 2), total_time))
+        start_refresh_time = time.time()
         refresh_providers(id_list)
+        refresh_time = time.time() - start_refresh_time
 
-        if time_left < wait_time:
+        if refresh_time > time_between_refresh:
+            logger.warning('refresh_time: {} is longer than time_between_refresh'.format(refresh_time))
+
+        if time_left < time_between_refresh:
             time.sleep(time_left)
         else:
-            time.sleep(wait_time)
+            time.sleep(time_between_refresh)
 
     logger.info('Test Ending...')

--- a/cfme-performance/tests/workloads/test_smartstate_analysis.py
+++ b/cfme-performance/tests/workloads/test_smartstate_analysis.py
@@ -9,6 +9,9 @@ from utils.conf import cfme_performance
 from utils.grafana import get_scenario_dashboard_url
 from utils.log import logger
 from utils.providers import add_providers
+from utils.providers import get_all_vm_ids
+from utils.providers import add_host_credentials
+from utils.providers import scan_provider_vm
 from utils.smem_memory_monitor import SmemMemoryMonitor
 from utils.ssh import SSHClient
 from utils.workloads import get_smartstate_analysis_scenarios
@@ -52,8 +55,23 @@ def test_workload_smartstate_analysis(request, scenario):
     time.sleep(scenario['refresh_sleep_time'])
 
     # TODO: add credentials to hosts via REST API here (VMware)
-    # TODO: Set appliance host/relationship (RHEVM)
-    set_cfme_server_relationship(ssh_client, cfme_performance['appliance']['appliance_name'])
+    for provider in scenario['providers']:
+        add_host_credentials(provider)
+        if provider['type'] == "ManageIQ::Providers::Redhat::InfraManager":
+            set_cfme_server_relationship(ssh_client, cfme_performance['appliance']['appliance_name'])
+
     # TODO: Implement Smart state analysis workload here
+    time_between_analyses = scenario['time_between_analyses']
+    total_time = scenario['total_time']
+    total_waited = 0
+    while (total_waited < total_time):
+        for vm_to_scan in get_all_vm_ids():
+            start_scan_time = time.time()
+            scan_provider_vm(vm_to_scan)
+            scan_time = time.time() - start_scan_time
+
+
+
+
 
     logger.info('Test Ending...')


### PR DESCRIPTION
Changes to cfme_performance.yml
    - Rename specifications to reduce confusion
    - Add host_credentials to vmware providers

Changes to test_refresh_providers.py
    - Account for changes in config files
    - Add logger warning messages if refresh time is longer than time between refreshes

Changes to test_refresh_vms.py
    - Account for changes in config files
    - Utilize cycler library instead of writing method
    - Add logger warning messages if refresh time is longer than time between refreshes

Changes to test_smartstate_analysis.py
    - Implement stubbs within providers.py

Changes to providers.py
    - Add get_all_host_ids() method
    - Reduce verbosity of methods by changign to vdebug messages
    - Add time functionality to the following methods:
        - refresh_providers
        - refresh_provider_vms()
