### PR TITLE
enable sprout for jenkins run. 

### DIFF
--- a/cfme-performance/utils/log.py
+++ b/cfme-performance/utils/log.py
@@ -6,6 +6,7 @@ import warnings
 
 # Additional Verbose Debug level
 VDEBUG_LEVEL = 9
+TRACE_LEVEL = 5
 
 MARKER_LEN = 80
 
@@ -62,12 +63,18 @@ def format_marker(mstring, mark="-"):
         mstring = format_spec.format(mstring)
     return mstring
 
+def trace(self, message, *args, **kws):
+    self._log(TRACE_LEVEL, message, args, **kws)
+
 
 def vdebug(self, message, *args, **kws):
     self._log(VDEBUG_LEVEL, message, args, **kws)
 logging.Logger.vdebug = vdebug
 
 logging.addLevelName(VDEBUG_LEVEL, "VDEBUG")
+
+logging.Logger.trace = trace
+logging.addLevelName(TRACE_LEVEL, "TRACE")
 
 logger = logging.getLogger('cfme-performance')
 logger.setLevel(cfme_performance['logging']['level'])

--- a/cfme-performance/utils/sprout.py
+++ b/cfme-performance/utils/sprout.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import json
+import requests
+
+from functools import partial
+from utils.conf import cfme_performance
+from wait_for import wait_for as wait_for_mod
+
+
+class SproutException(Exception):
+    pass
+
+
+class AuthException(SproutException):
+    pass
+
+
+class APIMethodCall(object):
+    def __init__(self, client, method_name):
+        self._client = client
+        self._method_name = method_name
+
+    def __call__(self, *args, **kwargs):
+        return self._client.call_method(self._method_name, *args, **kwargs)
+
+
+class SproutClient(object):
+    def __init__(
+            self, protocol="http", host="localhost", port=8000, entry="appliances/api", auth=None):
+        self._proto = protocol
+        self._host = host
+        self._port = port
+        self._entry = entry
+        self._auth = auth
+
+    @property
+    def api_entry(self):
+        return "{}://{}:{}/{}".format(self._proto, self._host, self._port, self._entry)
+
+    def _post(self, **data):
+        return requests.post(self.api_entry, data=json.dumps(data))
+
+    def _call_post(self, **data):
+        """Protect from the Sprout being updated (error 502,503)"""
+        wait_for = partial(wait_for_mod)
+        result = wait_for(
+            lambda: self._post(**data),
+            num_sec=60,
+            fail_condition=lambda r: r.status_code in {502, 503},
+            delay=2,
+        )
+        return result.out.json()
+
+    def call_method(self, name, *args, **kwargs):
+        req_data = {
+            "method": name,
+            "args": args,
+            "kwargs": kwargs,
+        }
+        if self._auth is not None:
+            req_data["auth"] = self._auth
+        result = self._call_post(**req_data)
+        try:
+            if result["status"] == "exception":
+                raise SproutException(
+                    "Exception {} raised! {}".format(
+                        result["result"]["class"], result["result"]["message"]))
+            elif result["status"] == "autherror":
+                raise AuthException(
+                    "Authentication failed! {}".format(result["result"]["message"]))
+            else:
+                return result["result"]
+        except KeyError:
+            raise Exception("Malformed response from Sprout!")
+
+    def __getattr__(self, attr):
+        return APIMethodCall(self, attr)
+
+    @classmethod
+    def from_config(cls, **kwargs):
+        host = cfme_performance.get("sprout", {}).get("hostname", "localhost")
+        port = cfme_performance.get("sprout", {}).get("port", 8000)
+        user = cfme_performance.get("sprout", {}).get("username", None)
+        password = cfme_performance.get("sprout", {}).get("password", None)
+        if user and password:
+            auth = user, password
+        else:
+            auth = None
+        return cls(host=host, port=port, auth=auth, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.10.0
 yaycl==0.2.0
 pycurl==7.43.0
 mgmtsystem==1.2.19
+diaper==1.3


### PR DESCRIPTION
 --use-sprout can be used to provision appliance
        from sprout. the lease time for performance test
        appliance would be 1 week by default.
  --appliance-name also can be specified for py.test
        commandline option along with --appliance
