### PR TITLE
Add pytest_generator which adds scenario name to test rather index.

### DIFF
--- a/cfme-performance/tests/workloads/test_idle.py
+++ b/cfme-performance/tests/workloads/test_idle.py
@@ -13,8 +13,13 @@ import time
 import pytest
 
 
+def pytest_generate_tests(metafunc):
+    argvalues = [[scenario] for scenario in get_idle_scenarios()]
+    idlist = [scenario['name'] for scenario in get_idle_scenarios()]
+    metafunc.parametrize(['scenario'], argvalues, ids=idlist)
+
+
 @pytest.mark.usefixtures('generate_version_files')
-@pytest.mark.parametrize('scenario', get_idle_scenarios())
 def test_idle(request, scenario):
     """Runs an appliance at idle with specific roles turned on for specific amount of time. Memory
     Monitor creates graphs and summary at the end of the scenario."""


### PR DESCRIPTION
- added pytest_generator to idele tests.
  - the test generated with scenario names rather than index.
    e.g "test_idle[scenario0]" will be "test_idle[default]"
